### PR TITLE
Fix current URL value to be logged into database

### DIFF
--- a/app/code/community/EW/UntranslatedStrings/Model/Core/Translate.php
+++ b/app/code/community/EW/UntranslatedStrings/Model/Core/Translate.php
@@ -244,7 +244,7 @@ class EW_UntranslatedStrings_Model_Core_Translate extends Mage_Core_Model_Transl
                 'text' => $text,
                 'store_id' => Mage::app()->getStore()->getId(),
                 'locale' => $locale,
-                'url' => Mage::helper('core/url')->getCurrentUrl()
+                'url' => $this->getCurrentUrl(),
             );
 
             $strings[$locale] = $localeStrings; //update "big" array
@@ -294,5 +294,12 @@ class EW_UntranslatedStrings_Model_Core_Translate extends Mage_Core_Model_Transl
         // END EDIT
         $this->_addData($this->_getFileData($file), false, $forceReload);
         return $this;
+    }
+
+    protected function getCurrentUrl()
+    {
+        $baseUrl = trim(Mage::app()->getStore()->getBaseUrl(), '/');
+        $requestUri = trim(Mage::app()->getRequest()->getRequestString(), '/');
+        return $baseUrl . '/' . $requestUri;
     }
 }


### PR DESCRIPTION
by using base link URL instead of core helper's current URL getter
Problem was that URLs missed the storecode prefix as it was not part
of the base URL in Magento's configuration.